### PR TITLE
Fix leaked CGImageRef.

### DIFF
--- a/Source/AGTransformPixelMapper.h
+++ b/Source/AGTransformPixelMapper.h
@@ -43,6 +43,6 @@
     bytesPerPixel:(size_t)bytesPerPixel
       bytesPerRow:(size_t)bytesPerRow;
 
-- (CGImageRef)createMappedImageRefFrom:(CGImageRef)imageRef scale:(double)scale;
+- (CGImageRef)createMappedImageRefFrom:(CGImageRef)imageRef scale:(double)scale CF_RETURNS_RETAINED;
 
 @end

--- a/Source/CGImageRef+CATransform3D.h
+++ b/Source/CGImageRef+CATransform3D.h
@@ -27,4 +27,4 @@ CGImageRef CGImageDrawWithCATransform3D(CGImageRef imageRef,
                                         CATransform3D transform,
                                         CGPoint anchorPoint,
                                         CGSize size,
-                                        CGFloat scale);
+                                        CGFloat scale) CF_RETURNS_RETAINED;

--- a/Source/UIImage+AGQuad.m
+++ b/Source/UIImage+AGQuad.m
@@ -34,7 +34,9 @@
     AGQuad scaledQuad = AGQuadApplyCATransform3D(quad, CATransform3DMakeScale(scale, scale, 1.0));
     CATransform3D transform = CATransform3DWithQuadFromBounds(scaledQuad, (CGRect){CGPointZero, self.size});
     CGImageRef imageRef = CGImageDrawWithCATransform3D(self.CGImage, transform, CGPointZero, self.size, 1.0);
-    return [UIImage imageWithCGImage:imageRef];
+    UIImage* image = [UIImage imageWithCGImage:imageRef];
+    CGImageRelease(imageRef);
+    return image;
 }
 
 

--- a/Source/UIImage+CATransform3D.m
+++ b/Source/UIImage+CATransform3D.m
@@ -30,7 +30,9 @@
 - (UIImage *)imageWithTransform:(CATransform3D)transform anchorPoint:(CGPoint)anchorPoint
 {
     CGImageRef imageRef = CGImageDrawWithCATransform3D(self.CGImage, transform, anchorPoint, self.size, self.scale);
-    return [UIImage imageWithCGImage:imageRef];
+    UIImage* image = [UIImage imageWithCGImage:imageRef];
+    CGImageRelease(imageRef);
+    return image;
 }
 
 @end


### PR DESCRIPTION
AGTransformPixelMapper createMappedImageRefFrom: leaks a CGImageRef (not sure why analyzer doesn't recognize "create" in method name). I marked two methods as CF_RETURNS_RETAINED to resolve this, and release returned CGImageRef after converting to UIImage.
