### PR TITLE
Fixed definition of AGKQuadInsetBottom and new definitions.

### DIFF
--- a/Source/AGKQuad.h
+++ b/Source/AGKQuad.h
@@ -65,6 +65,8 @@ CGPoint AGKQuadGetPointForCorner(AGKQuad q, AGKCorner corner);
 void AGKQuadGetXValues(AGKQuad q, CGFloat *out_values);
 void AGKQuadGetYValues(AGKQuad q, CGFloat *out_values);
 AGKQuad AGKQuadInterpolate(AGKQuad q1, AGKQuad q2, CGFloat progress);
+AGKQuad AGKQuadRotate(AGKQuad q, CGFloat radians);
+AGKQuad AGKQuadRotateAroundPoint(AGKQuad q, CGPoint point, CGFloat radians);
 AGKQuad AGKQuadApplyCGAffineTransform(AGKQuad q, CGAffineTransform t);
 AGKQuad AGKQuadApplyCATransform3D(AGKQuad q, CATransform3D t);
 NSString * NSStringFromAGKQuad(AGKQuad q);

--- a/Source/AGKQuad.m
+++ b/Source/AGKQuad.m
@@ -299,6 +299,32 @@ AGKQuad AGKQuadInterpolate(AGKQuad q1, AGKQuad q2, CGFloat progress)
     return q;
 }
 
+CGPoint CGPointRotatedAroundPoint(CGPoint point, CGPoint pivot, CGFloat radians) {
+    CGAffineTransform translation, rotation;
+    translation	= CGAffineTransformMakeTranslation(-pivot.x, -pivot.y);
+    point		= CGPointApplyAffineTransform(point, translation);
+    rotation	= CGAffineTransformMakeRotation(radians);
+    point		= CGPointApplyAffineTransform(point, rotation);
+    translation	= CGAffineTransformMakeTranslation(pivot.x, pivot.y);
+    point		= CGPointApplyAffineTransform(point, translation);
+    return point;
+}
+
+AGKQuad AGKQuadRotate(AGKQuad q, CGFloat radians)
+{
+    CGPoint center = AGKQuadGetCenter(q);
+    return AGKQuadRotateAroundPoint(q, center, radians);
+}
+
+AGKQuad AGKQuadRotateAroundPoint(AGKQuad q, CGPoint point, CGFloat radians)
+{
+    for(int i = 0; i < 4; i++)
+    {
+        q.v[i] = CGPointRotatedAroundPoint(q.v[i], point, radians);
+    }
+    return q;
+}
+
 AGKQuad AGKQuadApplyCGAffineTransform(AGKQuad q, CGAffineTransform t)
 {
     for(int i = 0; i < 4; i++)


### PR DESCRIPTION
Hi,

I've fixed the definition for AGKQuadInsetBottom to update q.bl and q.br instead of q.tl and q.tr.

I've also needed two new functions AGKQuadRotate, AGKQuadRotateAroundPoint that helps rotate AGKQuad better than using AGKQuadApplyCGAffineTransform. It makes use of the function CGPointRotatedAroundPoint that was copied over from the MTGeometry library.

Regards,
Basit
