### PR TITLE
Renamed unions to traditional structs to allow for Swift support.

### DIFF
--- a/Source/AGKLine.h
+++ b/Source/AGKLine.h
@@ -23,9 +23,9 @@
 
 #import <CoreGraphics/CoreGraphics.h>
 
-typedef union AGKLine {
-    struct { CGPoint start, end; };
-    double v[2];
+typedef struct AGKLine {
+    CGPoint start;
+    CGPoint end;
 } AGKLine;
 
 const AGKLine AGKLineZero;

--- a/Source/AGKQuad.h
+++ b/Source/AGKQuad.h
@@ -35,9 +35,11 @@
  bl = bottom left
  */
 
-typedef union AGKQuad {
-    struct { CGPoint tl, tr, br, bl; };
-    CGPoint v[4];
+typedef struct {
+    CGPoint tl;
+    CGPoint tr;
+    CGPoint br;
+    CGPoint bl;
 } AGKQuad;
 
 const AGKQuad AGKQuadZero;

--- a/Source/AGKQuad.m
+++ b/Source/AGKQuad.m
@@ -49,26 +49,45 @@ const AGKQuad AGKQuadZero = { (CGPoint){0, 0}, (CGPoint){0, 0}, (CGPoint){0, 0},
 
 BOOL AGKQuadEqual(AGKQuad q1, AGKQuad q2)
 {
-    for(int i = 0; i < 4; i++)
+    if (!CGPointEqualToPoint(q1.tl, q2.tl)) {
+        return NO;
+    }
+    if (!CGPointEqualToPoint(q1.tr, q2.tr)) {
+        return NO;
+    }
+    if (!CGPointEqualToPoint(q1.br, q2.br)) {
+        return NO;
+    }
+    if (!CGPointEqualToPoint(q1.bl, q2.bl)) {
+        return NO;
+    }
+    return YES;
+}
+
+BOOL CGPointEqualWithAccuracy(CGPoint p1, CGPoint p2, CGFloat accuracy)
+{
+    CGFloat xDiff = fabs(p1.x - p2.x);
+    CGFloat yDiff = fabs(p1.y - p2.y);
+    if(xDiff > accuracy || yDiff > accuracy)
     {
-        if(!CGPointEqualToPoint(q1.v[i], q2.v[i]))
-        {
-            return NO;
-        }
+        return NO;
     }
     return YES;
 }
 
 BOOL AGKQuadEqualWithAccuracy(AGKQuad q1, AGKQuad q2, CGFloat accuracy)
 {
-    for(int i = 0; i < 4; i++)
-    {
-        CGFloat xDiff = fabs(q1.v[i].x - q2.v[i].x);
-        CGFloat yDiff = fabs(q1.v[i].y - q2.v[i].y);
-        if(xDiff > accuracy || yDiff > accuracy)
-        {
-            return NO;
-        }
+    if (!CGPointEqualWithAccuracy(q1.tl, q2.tl, accuracy)) {
+        return NO;
+    }
+    else if (!CGPointEqualWithAccuracy(q1.tr, q2.tr, accuracy)) {
+        return NO;
+    }
+    else if (!CGPointEqualWithAccuracy(q1.br, q2.br, accuracy)) {
+        return NO;
+    }
+    else if (!CGPointEqualWithAccuracy(q1.bl, q2.bl, accuracy)) {
+        return NO;
     }
     return YES;
 }
@@ -79,14 +98,28 @@ BOOL AGKQuadIsConvex(AGKQuad q)
     return isConvex;
 }
 
+BOOL CGPointContainsValidValues(CGPoint p)
+{
+    if(isnan(p.x) || isnan(p.y) || isinf(p.x) || isinf(p.y))
+    {
+        return NO;
+    }
+    return YES;
+}
+
 BOOL AGKQuadContainsValidValues(AGKQuad q)
 {
-    for(int i = 0; i < 4; i++)
-    {
-        if(isnan(q.v[i].x) || isnan(q.v[i].y) || isinf(q.v[i].x) || isinf(q.v[i].y))
-        {
-            return NO;
-        }
+    if (!CGPointContainsValidValues(q.tl)) {
+        return NO;
+    }
+    else if (!CGPointContainsValidValues(q.tr)) {
+        return NO;
+    }
+    else if (!CGPointContainsValidValues(q.bl)) {
+        return NO;
+    }
+    else if (!CGPointContainsValidValues(q.br)) {
+        return NO;
     }
     return YES;
 }
@@ -268,34 +301,48 @@ CGSize AGKQuadGetSize(AGKQuad q)
 CGPoint AGKQuadGetPointForCorner(AGKQuad q, AGKCorner corner)
 {
     int index = AGKQuadCornerIndexForCorner(corner);
-    return q.v[index];
+    switch (index) {
+        case 0:
+            return q.tl;
+            break;
+        case 1:
+            return q.tr;
+            break;
+        case 2:
+            return q.br;
+            break;
+        case 3:
+            return q.bl;
+            break;
+        default:
+            return CGPointZero;
+            break;
+    }
 }
 
 void AGKQuadGetXValues(AGKQuad q, CGFloat *out_values)
 {
-    for(int i = 0; i < 4; i++)
-    {
-        CGPoint p = q.v[i];
-        out_values[i] = p.x;
-    }
+    out_values[0] = q.tl.x;
+    out_values[1] = q.tr.x;
+    out_values[2] = q.br.x;
+    out_values[3] = q.bl.x;
 }
 
 void AGKQuadGetYValues(AGKQuad q, CGFloat *out_values)
 {
-    for(int i = 0; i < 4; i++)
-    {
-        CGPoint p = q.v[i];
-        out_values[i] = p.y;
-    }
+    out_values[0] = q.tl.y;
+    out_values[1] = q.tr.y;
+    out_values[2] = q.br.y;
+    out_values[3] = q.bl.y;
 }
 
 AGKQuad AGKQuadInterpolate(AGKQuad q1, AGKQuad q2, CGFloat progress)
 {
     AGKQuad q;
-    for(int i = 0; i < 4; i++)
-    {
-        q.v[i] = CGPointInterpolate_AGK(q1.v[i], q2.v[i], progress);
-    }
+    q.tl = CGPointInterpolate_AGK(q1.tl, q2.tl, progress);
+    q.tr = CGPointInterpolate_AGK(q1.tr, q2.tr, progress);
+    q.br = CGPointInterpolate_AGK(q1.br, q2.br, progress);
+    q.bl = CGPointInterpolate_AGK(q1.bl, q2.bl, progress);
     return q;
 }
 
@@ -307,28 +354,28 @@ AGKQuad AGKQuadRotate(AGKQuad q, CGFloat radians)
 
 AGKQuad AGKQuadRotateAroundPoint(AGKQuad q, CGPoint point, CGFloat radians)
 {
-    for(int i = 0; i < 4; i++)
-    {
-        q.v[i] = CGPointRotateAroundOrigin_AGK(q.v[i], radians, point);
-    }
+    q.tl = CGPointRotateAroundOrigin_AGK(q.tl, radians, point);
+    q.tr = CGPointRotateAroundOrigin_AGK(q.tr, radians, point);
+    q.br = CGPointRotateAroundOrigin_AGK(q.br, radians, point);
+    q.bl = CGPointRotateAroundOrigin_AGK(q.bl, radians, point);
     return q;
 }
 
 AGKQuad AGKQuadApplyCGAffineTransform(AGKQuad q, CGAffineTransform t)
 {
-    for(int i = 0; i < 4; i++)
-    {
-        q.v[i] = CGPointApplyAffineTransform(q.v[i], t);
-    }
+    q.tl = CGPointApplyAffineTransform(q.tl, t);
+    q.tr = CGPointApplyAffineTransform(q.tr, t);
+    q.br = CGPointApplyAffineTransform(q.br, t);
+    q.bl = CGPointApplyAffineTransform(q.bl, t);
     return q;
 }
 
 AGKQuad AGKQuadApplyCATransform3D(AGKQuad q, CATransform3D t)
 {
-    for(int i = 0; i < 4; i++)
-    {
-        q.v[i] = CGPointApplyCATransform3D_AGK(q.v[i], t, CGPointZero, CATransform3DIdentity);
-    }
+    q.tl = CGPointApplyCATransform3D_AGK(q.tl, t, CGPointZero, CATransform3DIdentity);
+    q.tr = CGPointApplyCATransform3D_AGK(q.tr, t, CGPointZero, CATransform3DIdentity);
+    q.br = CGPointApplyCATransform3D_AGK(q.br, t, CGPointZero, CATransform3DIdentity);
+    q.bl = CGPointApplyCATransform3D_AGK(q.bl, t, CGPointZero, CATransform3DIdentity);
     return q;
 }
 

--- a/Source/Categories/NSValue+AGKQuad.m
+++ b/Source/Categories/NSValue+AGKQuad.m
@@ -28,12 +28,16 @@
 + (NSValue *)valueWithAGKQuad:(AGKQuad)q
 {
     CGFloat values[8];
-    for(int i = 0; i < 4; i++)
-    {
-        CGPoint p = q.v[i];
-        values[(i*2)] = p.x;
-        values[(i*2)+1] = p.y;
-    }
+    
+    values[0] = q.tl.x;
+    values[1] = q.tl.y;
+    values[2] = q.tr.x;
+    values[3] = q.tr.y;
+    values[4] = q.br.x;
+    values[5] = q.br.y;
+    values[6] = q.bl.x;
+    values[7] = q.bl.y;
+    
     NSValue *value = [NSValue value:&q withObjCType:@encode(CGFloat[8])];
     return value;
 }
@@ -43,11 +47,12 @@
     AGKQuad q = AGKQuadZero;
     CGFloat values[8];
     [self getValue:values];
-    for(int i = 0; i < 4; i++)
-    {
-        CGPoint p = CGPointMake(values[(i*2)], values[(i*2)+1]);
-        q.v[i] = p;
-    }
+    
+    q.tl = CGPointMake(values[0], values[1]);
+    q.tr = CGPointMake(values[2], values[3]);
+    q.br = CGPointMake(values[4], values[5]);
+    q.bl = CGPointMake(values[6], values[7]);
+    
     return q;
 }
 

--- a/Source/Categories/UIBezierPath+AGKQuad.m
+++ b/Source/Categories/UIBezierPath+AGKQuad.m
@@ -28,13 +28,10 @@
 + (UIBezierPath *)bezierPathWithAGKQuad:(AGKQuad)q
 {
     UIBezierPath *path = [UIBezierPath bezierPath];
-    [path moveToPoint:q.v[0]];
-    
-    for (int i = 1; i < 4; i++)
-    {
-        [path addLineToPoint:q.v[i]];
-    }
-    
+    [path moveToPoint:q.tl];
+    [path addLineToPoint:q.tr];
+    [path addLineToPoint:q.br];
+    [path addLineToPoint:q.bl];
     [path closePath];
     
     return path;

--- a/Source/Categories/UIImage+AGKQuad.m
+++ b/Source/Categories/UIImage+AGKQuad.m
@@ -171,38 +171,50 @@
     AGKMatrix *firstMatrix = [AGKMatrix matrixWithColumns:8 rows:8];
     AGKMatrix *secondMatrix = [AGKMatrix matrixWithColumns:1 rows:8];
     
+    CGPoint sourceQuadV[4];
+    sourceQuadV[0] = sourceQuad.tl;
+    sourceQuadV[1] = sourceQuad.tr;
+    sourceQuadV[2] = sourceQuad.br;
+    sourceQuadV[3] = sourceQuad.br;
+    
+    CGPoint destinationQuadV[4];
+    destinationQuadV[0] = destinationQuad.tl;
+    destinationQuadV[1] = destinationQuad.tr;
+    destinationQuadV[2] = destinationQuad.br;
+    destinationQuadV[3] = destinationQuad.bl;
+    
     for (NSInteger i = 0; i < 4; i++)
     {
-		[firstMatrix setObject:@(sourceQuad.v[i].x) atColumnIndex:0 rowIndex:i];
-		[firstMatrix setObject:@(sourceQuad.v[i].y) atColumnIndex:1 rowIndex:i];
-		[firstMatrix setObject:@1.0 atColumnIndex:2 rowIndex:i];
-		[firstMatrix setObject:@(sourceQuad.v[i].x) atColumnIndex:3 rowIndex:i + 4];
-		[firstMatrix setObject:@(sourceQuad.v[i].y) atColumnIndex:4 rowIndex:i + 4];
-		[firstMatrix setObject:@1.0 atColumnIndex:5 rowIndex:i + 4];
-		
-		[firstMatrix setObject:@0.0 atColumnIndex:3 rowIndex:i];
-		[firstMatrix setObject:@0.0 atColumnIndex:4 rowIndex:i];
-		[firstMatrix setObject:@0.0 atColumnIndex:5 rowIndex:i];
-		[firstMatrix setObject:@0.0 atColumnIndex:0 rowIndex:i + 4];
-		[firstMatrix setObject:@0.0 atColumnIndex:1 rowIndex:i + 4];
-		[firstMatrix setObject:@0.0 atColumnIndex:2 rowIndex:i + 4];
-		
-		[firstMatrix setObject:@(-sourceQuad.v[i].x * destinationQuad.v[i].x) atColumnIndex:6 rowIndex:i];
-		[firstMatrix setObject:@(-sourceQuad.v[i].y * destinationQuad.v[i].x) atColumnIndex:7 rowIndex:i];
-		[firstMatrix setObject:@(-sourceQuad.v[i].x * destinationQuad.v[i].y) atColumnIndex:6 rowIndex:i + 4];
-		[firstMatrix setObject:@(-sourceQuad.v[i].y * destinationQuad.v[i].y) atColumnIndex:7 rowIndex:i + 4];
-		
-		[secondMatrix setObject:@(destinationQuad.v[i].x) atColumnIndex:0 rowIndex:i];
-		[secondMatrix setObject:@(destinationQuad.v[i].y) atColumnIndex:0 rowIndex:i + 4];
-	}
+        [firstMatrix setObject:@(sourceQuadV[i].x) atColumnIndex:0 rowIndex:i];
+        [firstMatrix setObject:@(sourceQuadV[i].y) atColumnIndex:1 rowIndex:i];
+        [firstMatrix setObject:@1.0 atColumnIndex:2 rowIndex:i];
+        [firstMatrix setObject:@(sourceQuadV[i].x) atColumnIndex:3 rowIndex:i + 4];
+        [firstMatrix setObject:@(sourceQuadV[i].y) atColumnIndex:4 rowIndex:i + 4];
+        [firstMatrix setObject:@1.0 atColumnIndex:5 rowIndex:i + 4];
+        
+        [firstMatrix setObject:@0.0 atColumnIndex:3 rowIndex:i];
+        [firstMatrix setObject:@0.0 atColumnIndex:4 rowIndex:i];
+        [firstMatrix setObject:@0.0 atColumnIndex:5 rowIndex:i];
+        [firstMatrix setObject:@0.0 atColumnIndex:0 rowIndex:i + 4];
+        [firstMatrix setObject:@0.0 atColumnIndex:1 rowIndex:i + 4];
+        [firstMatrix setObject:@0.0 atColumnIndex:2 rowIndex:i + 4];
+        
+        [firstMatrix setObject:@(-sourceQuadV[i].x * destinationQuadV[i].x) atColumnIndex:6 rowIndex:i];
+        [firstMatrix setObject:@(-sourceQuadV[i].y * destinationQuadV[i].x) atColumnIndex:7 rowIndex:i];
+        [firstMatrix setObject:@(-sourceQuadV[i].x * destinationQuadV[i].y) atColumnIndex:6 rowIndex:i + 4];
+        [firstMatrix setObject:@(-sourceQuadV[i].y * destinationQuadV[i].y) atColumnIndex:7 rowIndex:i + 4];
+        
+        [secondMatrix setObject:@(destinationQuadV[i].x) atColumnIndex:0 rowIndex:i];
+        [secondMatrix setObject:@(destinationQuadV[i].y) atColumnIndex:0 rowIndex:i + 4];
+    }
     
     // Solve for the two matrices
     AGKMatrix *matrixA = [AGKMatrix matrixWithMatrix:firstMatrix];
     [matrixA transpose];
     NSUInteger rowCount = matrixA.rowCount;
     AGKMatrix *matrixV = [AGKMatrix matrixWithColumns:rowCount rows:rowCount];
-	AGKMatrix *matrixW = [self jacobiSVDForMatrixA:matrixA matrixV:matrixV];
-	AGKMatrix *matrixX = [self singleValueBackSubstitutionForColumns:matrixA.columnCount rows:rowCount wMatrix:matrixW uMatrix:matrixA vMatrix:matrixV bMatrix:secondMatrix];
+    AGKMatrix *matrixW = [self jacobiSVDForMatrixA:matrixA matrixV:matrixV];
+    AGKMatrix *matrixX = [self singleValueBackSubstitutionForColumns:matrixA.columnCount rows:rowCount wMatrix:matrixW uMatrix:matrixA vMatrix:matrixV bMatrix:secondMatrix];
     
     AGKMatrix *perspectiveMatrix = [matrixX matrixWithColumnSize:3 rowSize:3 andTranspose:YES];
     [perspectiveMatrix setObject:@1 atIndexedSubscript:(perspectiveMatrix.count - 1)];


### PR DESCRIPTION
Unfortunately, Swift seems unable to convert `union` types properly.  I converted the `AGKQuad` & `AGKLine` properties to a traditional `struct` types to allow for better inter-compatibility.  If people want to access the `.v` member variable of the `AGKQuad`, they can add this extension to their Swift code:

``` Swift
extension AGKQuad {
    var v: [CGPoint] {
    get {
        return [tl, tr, br, bl]
    }
    set {
        tl = newValue[0]
        tr = newValue[1]
        br = newValue[2]
        bl = newValue[3]
    }
    }
}
```

This will unfortunately lose the ability to use the `v` member variable in traditional ObjC code, so perhaps a separate branch devoted to Swift support would be useful.  I'm not sure how often this variable is used outside of the AGGeometryKit framework.
