### PR TITLE
Adding subspec for frame accessor

### DIFF
--- a/AGGeometryKit.podspec
+++ b/AGGeometryKit.podspec
@@ -35,6 +35,7 @@ Pod::Spec.new do |s|
     end
 
     s.subspec 'FrameAccessor' do |ss|
+        ss.frameworks    = 'CoreGraphics', 'QuartzCore'
         ss.source_files        = 'Source/Categories/UIView+AGK+Properties.{h,m}', 'Source/CoreGraphics_Extensions/CGGeometry+AGGeometryKit.{h,m}'
     end
 end


### PR DESCRIPTION
Makes it easy to use the excellent frame accessors that you have provided in AGGeometryKit, even when you don't need the full kit.
