### PR TITLE
Fixed compile error due to duplicate symbols

### DIFF
--- a/Source/AGKLine.h
+++ b/Source/AGKLine.h
@@ -28,7 +28,7 @@ typedef union AGKLine {
     double v[2];
 } AGKLine;
 
-const AGKLine AGKLineZero;
+extern const AGKLine AGKLineZero;
 AGKLine AGKLineMake(CGPoint start, CGPoint end);
 double AGKLineLength(AGKLine l);
 BOOL AGKLineIntersection(AGKLine l1, AGKLine l2, CGPoint *out_pointOfIntersection);

--- a/Source/AGKQuad.h
+++ b/Source/AGKQuad.h
@@ -40,7 +40,7 @@ typedef union AGKQuad {
     CGPoint v[4];
 } AGKQuad;
 
-const AGKQuad AGKQuadZero;
+extern const AGKQuad AGKQuadZero;
 BOOL AGKQuadEqual(AGKQuad q1, AGKQuad q2);
 BOOL AGKQuadEqualWithAccuracy(AGKQuad q1, AGKQuad q2, CGFloat accuracy);
 BOOL AGKQuadIsConvex(AGKQuad q);

--- a/Source/AGKVector3D.h
+++ b/Source/AGKVector3D.h
@@ -34,7 +34,7 @@ struct AGKVector3D {
 };
 typedef struct AGKVector3D AGKVector3D;
 
-const AGKVector3D AGKVector3DZero;
+extern const AGKVector3D AGKVector3DZero;
 
 AGKVector3D AGKVector3DMake(CGFloat x, CGFloat y, CGFloat z);
 AGKVector3D AGKVector3DWithGLKVector3(GLKVector3);


### PR DESCRIPTION
If ``extern`` is omitted linker issues arise such as the following:

```
duplicate symbol _AGKLineZero in:
    /[...]/Objects-normal/x86_64/MyFile.o
    /[...]/libPods-AGGeometryKit.a(AGKLine.o)
ld: 1 duplicate symbols for architecture x86_64
```