### PR TITLE
Make static analyzer not warn about NSNumber * pointer values as boolean

### DIFF
--- a/AGGeometryKit/Classes/AGKMatrix.m
+++ b/AGGeometryKit/Classes/AGKMatrix.m
@@ -208,7 +208,7 @@ typedef NS_ENUM(NSUInteger, AGKMatrixDimension) {
 #pragma mark - Member Management
 
 - (NSNumber *)defaultMember {
-	if (!_defaultMember) {
+	if (_defaultMember == nil) {
 		_defaultMember = @0;
 	}
 	
@@ -216,7 +216,7 @@ typedef NS_ENUM(NSUInteger, AGKMatrixDimension) {
 }
 
 - (void)resetMatrixToDefault:(NSNumber *)defaultValue {
-    if (defaultValue) {
+    if (defaultValue != nil) {
         self.defaultMember = defaultValue;
     }
 	self.members = nil;


### PR DESCRIPTION
Hi again! Here's another PR. 

I don't know why, but these static analyzer issues show up when I build my project (with AGGeometryKit as a pod) – they don't show up when I run Analyze in the AGGeometryKit itself. 

These changes should be identical in behavior to the previous code, but maybe someone who understands the code should also verify that it indeed is also the intended behavior. :) 